### PR TITLE
Add numbers to regex

### DIFF
--- a/examples/failover/failover-existing-network.yaml
+++ b/examples/failover/failover-existing-network.yaml
@@ -228,7 +228,7 @@ Parameters:
     Description: Application Tag.
     Type: String
   artifactLocation:
-    AllowedPattern: ^.*[a-zA-Z]+/$
+    AllowedPattern: ^.*[0-9a-zA-Z]+/$
     ConstraintDescription: key prefix can include numbers, lowercase letters, uppercase
       letters, hyphens (-), and forward slash (/).
     Default: f5-aws-cloudformation-v2/v2.0.0.0/examples/


### PR DESCRIPTION
#### What issues does this address?
Fix the regex in `AllowedPattern` to match the written description in `ConstraintDescription`

#### What does this change do?
This change allows integers in s3 `artifactLocation` keys, such as `v1/`

#### Where should the reviewer start?
n/a

#### Any background context?
No